### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/datolabs-io/opsy/security/code-scanning/6](https://github.com/datolabs-io/opsy/security/code-scanning/6)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/ci.yaml`. The block should be placed at the top level (before `jobs:`) to apply to all jobs, unless a job requires more specific permissions. For build, lint, and test jobs, the minimal required permission is typically `contents: read`, which allows the workflow to read repository contents but not write to them. No additional permissions are needed for these jobs. The change should be made by inserting the following block after the workflow `name` and before the `on:` block:

```yaml
permissions:
  contents: read
```

No imports or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
